### PR TITLE
24: Own ActiveSupport::Concern

### DIFF
--- a/challenges/24_own_active_support_concern.rb
+++ b/challenges/24_own_active_support_concern.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#
+# 24: Own ActiveSupport::Concern
+#
+# BRIEF:
+#
+#   In this challenge need to imagine that you have no Rails
+#   and implement simple ActiveSupport::Concern module.
+#
+# EXAMPLE:
+#
+# module Custom
+#   include ActiveSupport::Concern
+#
+#   in_class do
+#     attr_accessor :foo, :bar
+#   end
+#
+#   class_methods do
+#     def test_class_method
+#       'Class method here'
+#     end
+#   end
+# end
+
+# class Pet
+#   include Custom
+# end
+
+# pet = Pet.new
+#
+# pet.instance_methods(false)
+#   => [:bar=, :foo, :bar, :foo=]
+#
+# pet.class.methods.include?(:test_class_method)
+#   => true
+#
+
+module ActiveSupport
+  module Concern
+    def self.included(mod)
+      mod.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def included(base)
+        base.class_eval &@included_block
+
+        const_set(:ClassMethods, Module.new)
+        const_get(:ClassMethods).module_eval &@class_methods_block
+
+        base.extend(const_get(:ClassMethods))
+      end
+
+      def in_class(&block)
+        @included_block = block
+      end
+
+      def class_methods(&block)
+        @class_methods_block = block
+      end
+    end
+  end
+end
+
+module Custom
+  include ActiveSupport::Concern
+
+  in_class do
+    attr_accessor :foo, :bar
+  end
+
+  class_methods do
+    def test_class_method
+      'Class method here'
+    end
+  end
+end
+
+Pet = Class.new do
+  include Custom
+end

--- a/spec/unit/24_own_active_support_concern_spec.rb
+++ b/spec/unit/24_own_active_support_concern_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require './challenges/24_own_active_support_concern'
+
+describe '24: Own ActiveSupport::Concern' do
+  let(:pet) do
+    Pet.new
+  end
+
+  it 'provides included imitation' do
+    expect(
+      pet.class.instance_methods(false)
+    ).to match_array(
+      [:bar=, :foo, :bar, :foo=]
+    )
+  end
+
+  it 'provides class_methods imitation' do
+    expect(
+      pet.class.methods
+    ).to include(
+      :test_class_method
+    )
+  end
+end


### PR DESCRIPTION
**BRIEF:**

  In this challenge need to imagine that you have no Rails
  and implement simple ActiveSupport::Concern module.

**EXAMPLE:**

```
module Custom
  include ActiveSupport::Concern

  in_class do
    attr_accessor :foo, :bar
  end

  class_methods do
    def test_class_method
      'Class method here'
    end
  end
end

class Pet
  include Custom
end
```

And then:
```
pet = Pet.new

pet.instance_methods(false)
  => [:bar=, :foo, :bar, :foo=]

pet.class.methods.include?(:test_class_method)
  => true
```